### PR TITLE
FIX: concurrent map read and map write for `globalChunkTbl`, added mutex for globalChunkTbl read/write

### DIFF
--- a/drsm/api.go
+++ b/drsm/api.go
@@ -110,8 +110,8 @@ func (d *Drsm) ReleaseInt32ID(id int32) error {
 }
 
 func (d *Drsm) FindOwnerInt32ID(id int32) (*PodId, error) {
-	mutex.Lock()
-	defer mutex.Unlock()
+	d.globalChunkTblMutex.Lock()
+	defer d.globalChunkTblMutex.Unlock()
 	chunkId := id >> 10
 	chunk, found := d.globalChunkTbl[chunkId]
 	if found == true {

--- a/drsm/chunk.go
+++ b/drsm/chunk.go
@@ -31,7 +31,9 @@ func (d *Drsm) GetNewChunk() (*chunk, error) {
 	for {
 		for {
 			cn = rand.Int31n(d.chunkIdRange)
+			d.globalChunkTblMutex.Lock()
 			_, found := d.globalChunkTbl[cn]
+			d.globalChunkTblMutex.Unlock()
 			if found == true {
 				continue
 			}

--- a/drsm/claim.go
+++ b/drsm/claim.go
@@ -19,7 +19,9 @@ func (d *Drsm) podDownDetected() {
 			// Given Pod find out current Chunks owned by this POD
 			pd := d.podMap[p]
 			for k, _ := range pd.podChunks {
+				d.globalChunkTblMutex.Lock()
 				c, found := d.globalChunkTbl[k]
+				d.globalChunkTblMutex.Unlock()
 				logger.AppLog.Debugf("Found : %v chunk : %v ", found, c)
 				go c.claimChunk(d)
 			}

--- a/drsm/drsm.go
+++ b/drsm/drsm.go
@@ -45,22 +45,23 @@ type podData struct {
 }
 
 type Drsm struct {
-	mu              sync.Mutex
-	sharedPoolName  string
-	clientId        PodId
-	db              DbInfo
-	mode            DrsmMode
-	resIdSize       int32
-	localChunkTbl   map[int32]*chunk    // chunkid to chunk
-	globalChunkTbl  map[int32]*chunk    // chunkid to chunk
-	podMap          map[string]*podData // podId to podData
-	podDown         chan string
-	scanChunks      map[int32]*chunk
-	chunkIdRange    int32
-	resourceValidCb func(int32) bool
-	ipModule        ipam.Ipamer
-	prefix          map[string]*ipam.Prefix
-	mongo           *MongoDBLibrary.MongoClient
+	mu                  sync.Mutex
+	sharedPoolName      string
+	clientId            PodId
+	db                  DbInfo
+	mode                DrsmMode
+	resIdSize           int32
+	localChunkTbl       map[int32]*chunk    // chunkid to chunk
+	globalChunkTbl      map[int32]*chunk    // chunkid to chunk
+	podMap              map[string]*podData // podId to podData
+	podDown             chan string
+	scanChunks          map[int32]*chunk
+	chunkIdRange        int32
+	resourceValidCb     func(int32) bool
+	ipModule            ipam.Ipamer
+	prefix              map[string]*ipam.Prefix
+	mongo               *MongoDBLibrary.MongoClient
+	globalChunkTblMutex sync.Mutex
 }
 
 func (d *Drsm) DeletePod(podInstance string) {
@@ -87,6 +88,7 @@ func (d *Drsm) ConstuctDrsm(opt *Options) {
 	d.podMap = make(map[string]*podData)
 	d.podDown = make(chan string, 10)
 	d.scanChunks = make(map[int32]*chunk)
+	d.globalChunkTblMutex = sync.Mutex{}
 	t := time.Now().UnixNano()
 	rand.Seed(t)
 	d.initIpam(opt)

--- a/drsm/updates.go
+++ b/drsm/updates.go
@@ -157,7 +157,9 @@ func iterateChangeStream(d *Drsm, routineCtx context.Context, stream *mongo.Chan
 				// looks like chunk owner getting change
 				owner := s.Update.UpdFields.PodId
 				c := getChunIdFromDocId(s.DId.Id)
+				d.globalChunkTblMutex.Lock()
 				cp := d.globalChunkTbl[c]
+				d.globalChunkTblMutex.Unlock()
 				// TODO update IP address as well.
 				cp.Owner.PodName = owner
 				cp.Owner.PodIp = s.Update.UpdFields.PodIp
@@ -255,7 +257,10 @@ func (d *Drsm) addChunk(full *FullStream) {
 	c.resourceValidCb = d.resourceValidCb
 
 	pod.podChunks[cid] = c
+
+	d.globalChunkTblMutex.Lock()
 	d.globalChunkTbl[cid] = c
+	d.globalChunkTblMutex.Unlock()
 
 	logger.AppLog.Infof("Chunk id %v, podChunks %v ", cid, pod.podChunks)
 }


### PR DESCRIPTION
```fatal error: concurrent map read and map write

goroutine 2413 [running]:
runtime.throw({0xef3a56?, 0x10dd740?})
	/usr/local/go/src/runtime/panic.go:992 +0x71 fp=0xc001b47c00 sp=0xc001b47bd0 pc=0x436051
runtime.mapaccess2_fast32(0x0?, 0x4?, 0x1214)
	/usr/local/go/src/runtime/map_fast32.go:62 +0x176 fp=0xc001b47c20 sp=0xc001b47c00 pc=0x412776
github.com/omec-project/util/drsm.(*Drsm).FindOwnerInt32ID(0x9?, 0xa3e900?)
	/go/pkg/mod/github.com/omec-project/util@v1.0.9/drsm/api.go:114 +0x2f fp=0xc001b47c58 sp=0xc001b47c20 pc=0xc8c48f
main.RoundRobin(0x48532e)
	/go/src/sctplb/dispatcher.go:80 +0xd3 fp=0xc001b47d80 sp=0xc001b47c58 pc=0xc95f93
main.dispatchMessage({0x10d9310?, 0xc0001941e0}, {0xc0009b6000, 0x4a, 0x2000}, {0xc14ad0c33b62da84?, 0x7391ba0519?, 0x16a6b80?})
	/go/src/sctplb/dispatcher.go:840 +0x5df fp=0xc001b47f18 sp=0xc001b47d80 pc=0xc996ff
main.handleConnection.func2()
	/go/src/sctplb/service.go:185 +0xda fp=0xc001b47fe0 sp=0xc001b47f18 pc=0xc9c25a
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc001b47fe8 sp=0xc001b47fe0 pc=0x465781```
created by main.handleConnection
	/go/src/sctplb/service.go:180 +0x145