### PR TITLE
feat: Adding dbadapter to make DB integration easier

### DIFF
--- a/mongoapi/dbadapter.go
+++ b/mongoapi/dbadapter.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2024 Open Networking Foundation <info@opennetworking.org>
+// Copyright 2019 free5GC.org
+//
+// SPDX-License-Identifier: Apache-2.0
+package mongoapi
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type DBInterface interface {
+	RestfulAPIGetOne(collName string, filter bson.M) (map[string]interface{}, error)
+	RestfulAPIGetMany(collName string, filter bson.M) ([]map[string]interface{}, error)
+	RestfulAPIPutOneTimeout(collName string, filter bson.M, putData map[string]interface{}, timeout int32, timeField string) bool
+	RestfulAPIPutOne(collName string, filter bson.M, putData map[string]interface{}) (bool, error)
+	RestfulAPIPutOneNotUpdate(collName string, filter bson.M, putData map[string]interface{}) (bool, error)
+	RestfulAPIPutMany(collName string, filterArray []primitive.M, putDataArray []map[string]interface{}) error
+	RestfulAPIDeleteOne(collName string, filter bson.M) error
+	RestfulAPIDeleteMany(collName string, filter bson.M) error
+	RestfulAPIMergePatch(collName string, filter bson.M, patchData map[string]interface{}) error
+	RestfulAPIJSONPatch(collName string, filter bson.M, patchJSON []byte) error
+	RestfulAPIJSONPatchExtend(collName string, filter bson.M, patchJSON []byte, dataName string) error
+	RestfulAPIPost(collName string, filter bson.M, postData map[string]interface{}) (bool, error)
+	RestfulAPIPostMany(collName string, filter bson.M, postDataArray []interface{}) error
+	GetUniqueIdentity(idName string) int32
+	CreateIndex(collName string, keyField string) (bool, error)
+}
+
+var CommonDBClient DBInterface
+
+type MongoDBClient struct {
+	MongoClient
+}
+
+// Set CommonDBClient
+func setCommonDBClient(url string, dbname string) error {
+	var mClient, errConnect = NewMongoClient(url, dbname)
+	if mClient.Client != nil {
+		CommonDBClient = mClient
+		CommonDBClient.(*MongoClient).Client.Database(dbname)
+	}
+	return errConnect
+}
+
+func ConnectMongo(url string, dbname string) {
+	// Connect to MongoDB
+	ticker := time.NewTicker(2 * time.Second)
+	defer func() { ticker.Stop() }()
+	timer := time.After(180 * time.Second)
+ConnectMongo:
+	for {
+		commonDbErr := setCommonDBClient(url, dbname)
+		if commonDbErr == nil {
+			break ConnectMongo
+		}
+		select {
+		case <-ticker.C:
+			continue
+		case <-timer:
+			return
+		}
+	}
+}
+
+func (db *MongoDBClient) RestfulAPIGetOne(collName string, filter bson.M) (map[string]interface{}, error) {
+	return db.MongoClient.RestfulAPIGetOne(collName, filter)
+}
+
+func (db *MongoDBClient) RestfulAPIGetMany(collName string, filter bson.M) ([]map[string]interface{}, error) {
+	return db.MongoClient.RestfulAPIGetMany(collName, filter)
+}
+func (db *MongoDBClient) RestfulAPIPutOneTimeout(collName string, filter bson.M, putData map[string]interface{}, timeout int32, timeField string) bool {
+	return db.MongoClient.RestfulAPIPutOneTimeout(collName, filter, putData, timeout, timeField)
+}
+
+func (db *MongoDBClient) RestfulAPIPutOne(collName string, filter bson.M, putData map[string]interface{}) (bool, error) {
+	return db.MongoClient.RestfulAPIPutOne(collName, filter, putData)
+}
+
+func (db *MongoDBClient) RestfulAPIPutOneNotUpdate(collName string, filter bson.M, putData map[string]interface{}) (bool, error) {
+	return db.MongoClient.RestfulAPIPutOneNotUpdate(collName, filter, putData)
+}
+
+func (db *MongoDBClient) RestfulAPIPutMany(collName string, filterArray []primitive.M, putDataArray []map[string]interface{}) error {
+	return db.MongoClient.RestfulAPIPutMany(collName, filterArray, putDataArray)
+}
+
+func (db *MongoDBClient) RestfulAPIDeleteOne(collName string, filter bson.M) error {
+	return db.MongoClient.RestfulAPIDeleteOne(collName, filter)
+}
+
+func (db *MongoDBClient) RestfulAPIDeleteMany(collName string, filter bson.M) error {
+	return db.MongoClient.RestfulAPIDeleteMany(collName, filter)
+}
+
+func (db *MongoDBClient) RestfulAPIMergePatch(collName string, filter bson.M, patchData map[string]interface{}) error {
+	return db.MongoClient.RestfulAPIMergePatch(collName, filter, patchData)
+}
+
+func (db *MongoDBClient) RestfulAPIJSONPatch(collName string, filter bson.M, patchJSON []byte) error {
+	return db.MongoClient.RestfulAPIJSONPatch(collName, filter, patchJSON)
+}
+
+func (db *MongoDBClient) RestfulAPIJSONPatchExtend(collName string, filter bson.M, patchJSON []byte, dataName string) error {
+	return db.MongoClient.RestfulAPIJSONPatchExtend(collName, filter, patchJSON, dataName)
+}
+
+func (db *MongoDBClient) RestfulAPIPost(collName string, filter bson.M, postData map[string]interface{}) (bool, error) {
+	return db.MongoClient.RestfulAPIPost(collName, filter, postData)
+}
+
+func (db *MongoDBClient) RestfulAPIPostMany(collName string, filter bson.M, postDataArray []interface{}) error {
+	return db.MongoClient.RestfulAPIPostMany(collName, filter, postDataArray)
+}
+
+func (db *MongoDBClient) GetUniqueIdentity(idName string) int32 {
+	return db.MongoClient.GetUniqueIdentity(idName)
+}
+
+func (db *MongoDBClient) CreateIndex(collName string, keyField string) (bool, error) {
+	return db.MongoClient.CreateIndex(collName, keyField)
+}

--- a/mongoapi/dbtestapp/drsmapp.go
+++ b/mongoapi/dbtestapp/drsmapp.go
@@ -23,7 +23,7 @@ type drsmInterface struct {
 var drsmIntf drsmInterface
 
 func scanChunk(i int32) bool {
-	logger.AppLog.Debugf("Received callback from module to scan Chunk resource ", i)
+	logger.AppLog.Debugf("Received callback from module to scan Chunk resource %+v", i)
 	return false
 }
 
@@ -58,7 +58,7 @@ func initDrsm(resName string) {
 func AllocateInt32One(resName string) int32 {
 	id, err := drsmIntf.d.AllocateInt32ID()
 	if err != nil {
-		logger.AppLog.Debugf("Id allocation error ", err)
+		logger.AppLog.Debugf("Id allocation error %+v", err)
 		return 0
 	}
 	log.Printf("Received id %v ", id)
@@ -90,7 +90,7 @@ func AllocateInt32Many(resName string, number int32) []int32 {
 func ReleaseInt32One(resName string, resId int32) error {
 	err := drsmIntf.d.ReleaseInt32ID(resId)
 	if err != nil {
-		logger.AppLog.Debugf("Id release error ", err)
+		logger.AppLog.Debugf("Id release error %+v", err)
 		return err
 	}
 	return nil
@@ -99,7 +99,7 @@ func ReleaseInt32One(resName string, resId int32) error {
 func IpAddressAllocOne(pool string) (string, error) {
 	ip, err := drsmIntf.d.AcquireIp(pool)
 	if err != nil {
-		log.Printf("%v : Ip allocation error ", pool, err)
+		log.Printf("%+v : Ip allocation error %+v", pool, err)
 		return "", err
 	}
 	log.Printf("%v : Received ip %v ", pool, ip)


### PR DESCRIPTION
Adding dbadapter.go  file  to util/mongoapi  instead of creating it in each consumer repository.