### PR TITLE
feat: add MongoDB functions to handle transactions

### DIFF
--- a/mongoapi/dbadapter.go
+++ b/mongoapi/dbadapter.go
@@ -32,7 +32,7 @@ type DBInterface interface {
 	GetUniqueIdentity(idName string) int32
 	CreateIndex(collName string, keyField string) (bool, error)
 	StartSession() (mongo.Session, error)
-	IsReplicaSet() (bool, error)
+	SupportsTransactions() (bool, error)
 }
 
 var CommonDBClient DBInterface
@@ -142,6 +142,6 @@ func (db *MongoDBClient) StartSession() (mongo.Session, error) {
 	return db.MongoClient.StartSession()
 }
 
-func (db *MongoDBClient) IsReplicaSet() (bool, error) {
-	return db.MongoClient.IsReplicaSet()
+func (db *MongoDBClient) SupportsTransactions() (bool, error) {
+	return db.MongoClient.SupportsTransactions()
 }

--- a/mongoapi/dbadapter.go
+++ b/mongoapi/dbadapter.go
@@ -5,10 +5,12 @@
 package mongoapi
 
 import (
+	"context"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type DBInterface interface {
@@ -19,14 +21,18 @@ type DBInterface interface {
 	RestfulAPIPutOneNotUpdate(collName string, filter bson.M, putData map[string]interface{}) (bool, error)
 	RestfulAPIPutMany(collName string, filterArray []primitive.M, putDataArray []map[string]interface{}) error
 	RestfulAPIDeleteOne(collName string, filter bson.M) error
+	RestfulAPIDeleteOneWithContext(collName string, filter bson.M, context context.Context) error
 	RestfulAPIDeleteMany(collName string, filter bson.M) error
 	RestfulAPIMergePatch(collName string, filter bson.M, patchData map[string]interface{}) error
 	RestfulAPIJSONPatch(collName string, filter bson.M, patchJSON []byte) error
+	RestfulAPIJSONPatchWithContext(collName string, filter bson.M, patchJSON []byte, context context.Context) error
 	RestfulAPIJSONPatchExtend(collName string, filter bson.M, patchJSON []byte, dataName string) error
 	RestfulAPIPost(collName string, filter bson.M, postData map[string]interface{}) (bool, error)
 	RestfulAPIPostMany(collName string, filter bson.M, postDataArray []interface{}) error
 	GetUniqueIdentity(idName string) int32
 	CreateIndex(collName string, keyField string) (bool, error)
+	StartSession() (mongo.Session, error)
+	IsReplicaSet() (bool, error)
 }
 
 var CommonDBClient DBInterface
@@ -92,6 +98,10 @@ func (db *MongoDBClient) RestfulAPIDeleteOne(collName string, filter bson.M) err
 	return db.MongoClient.RestfulAPIDeleteOne(collName, filter)
 }
 
+func (db *MongoDBClient) RestfulAPIDeleteOneWithContext(collName string, filter bson.M, context context.Context) error {
+	return db.MongoClient.RestfulAPIDeleteOneWithContext(collName, filter, context)
+}
+
 func (db *MongoDBClient) RestfulAPIDeleteMany(collName string, filter bson.M) error {
 	return db.MongoClient.RestfulAPIDeleteMany(collName, filter)
 }
@@ -102,6 +112,10 @@ func (db *MongoDBClient) RestfulAPIMergePatch(collName string, filter bson.M, pa
 
 func (db *MongoDBClient) RestfulAPIJSONPatch(collName string, filter bson.M, patchJSON []byte) error {
 	return db.MongoClient.RestfulAPIJSONPatch(collName, filter, patchJSON)
+}
+
+func (db *MongoDBClient) RestfulAPIJSONPatchWithContext(collName string, filter bson.M, patchJSON []byte, context context.Context) error {
+	return db.MongoClient.RestfulAPIJSONPatchWithContext(collName, filter, patchJSON, context)
 }
 
 func (db *MongoDBClient) RestfulAPIJSONPatchExtend(collName string, filter bson.M, patchJSON []byte, dataName string) error {
@@ -122,4 +136,12 @@ func (db *MongoDBClient) GetUniqueIdentity(idName string) int32 {
 
 func (db *MongoDBClient) CreateIndex(collName string, keyField string) (bool, error) {
 	return db.MongoClient.CreateIndex(collName, keyField)
+}
+
+func (db *MongoDBClient) StartSession() (mongo.Session, error) {
+	return db.MongoClient.StartSession()
+}
+
+func (db *MongoDBClient) IsReplicaSet() (bool, error) {
+	return db.MongoClient.IsReplicaSet()
 }

--- a/mongoapi/mongoapi.go
+++ b/mongoapi/mongoapi.go
@@ -194,9 +194,13 @@ func (c *MongoClient) RestfulAPIPutMany(collName string, filterArray []bson.M, p
 }
 
 func (c *MongoClient) RestfulAPIDeleteOne(collName string, filter bson.M) error {
+	return c.RestfulAPIDeleteOneWithContext(collName, filter, context.TODO())
+}
+
+func (c *MongoClient) RestfulAPIDeleteOneWithContext(collName string, filter bson.M, context context.Context) error {
 	collection := c.Client.Database(c.dbName).Collection(collName)
 
-	if _, err := collection.DeleteOne(context.TODO(), filter); err != nil {
+	if _, err := collection.DeleteOne(context, filter); err != nil {
 		return fmt.Errorf("RestfulAPIDeleteOne err: %+v", err)
 	}
 	return nil
@@ -245,6 +249,10 @@ func (c *MongoClient) RestfulAPIMergePatch(collName string, filter bson.M, patch
 }
 
 func (c *MongoClient) RestfulAPIJSONPatch(collName string, filter bson.M, patchJSON []byte) error {
+	return c.RestfulAPIJSONPatchWithContext(collName, filter, patchJSON, context.TODO())
+}
+
+func (c *MongoClient) RestfulAPIJSONPatchWithContext(collName string, filter bson.M, patchJSON []byte, context context.Context) error {
 	collection := c.Client.Database(c.dbName).Collection(collName)
 
 	originalData, err := getOrigData(collection, filter)
@@ -271,7 +279,7 @@ func (c *MongoClient) RestfulAPIJSONPatch(collName string, filter bson.M, patchJ
 	if err := json.Unmarshal(modified, &modifiedData); err != nil {
 		return fmt.Errorf("RestfulAPIJSONPatch Unmarshal err: %+v", err)
 	}
-	if _, err := collection.UpdateOne(context.TODO(), filter, bson.M{"$set": modifiedData}); err != nil {
+	if _, err := collection.UpdateOne(context, filter, bson.M{"$set": modifiedData}); err != nil {
 		return fmt.Errorf("RestfulAPIJSONPatch UpdateOne err: %+v", err)
 	}
 	return nil
@@ -826,4 +834,21 @@ func (c *MongoClient) RestfulAPIPutOnly(collName string, filter bson.M, putData 
 	}
 	err = fmt.Errorf("failed to update document: %s", err)
 	return err
+}
+
+func (c *MongoClient) StartSession() (mongo.Session, error) {
+	return c.Client.StartSession()
+}
+
+func (c *MongoClient) IsReplicaSet() (bool, error) {
+	command := bson.D{{"hello", 1}}
+	result := c.Client.Database(c.dbName).RunCommand(context.Background(), command)
+	var status bson.M
+	if err := result.Decode(&status); err != nil {
+		return false, fmt.Errorf("failed to get server status: %v", err)
+	}
+	if _, ok := status["setName"]; ok {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
This PR adds 4 functions needed to handle transactions in mongoDB.

We would like to use transactions to ensure Atomicity in operations that perform 2 or more actions over the DB. With transactions, the operations are rolled back in case of failure. https://www.mongodb.com/docs/manual/core/transactions/

Transactions can only be used in Replica Set or sharded deployments.

Operations in a transaction use a shared `mongo.SessionContext` instead of separate `context.TODO()`