### PR TITLE
feat: Add NFConfig type to Logger

### DIFF
--- a/logger/logger_config.go
+++ b/logger/logger_config.go
@@ -14,6 +14,7 @@ type Logger struct {
 	AMF      *LogSetting `yaml:"AMF" valid:"optional"`
 	AUSF     *LogSetting `yaml:"AUSF" valid:"optional"`
 	N3IWF    *LogSetting `yaml:"N3IWF" valid:"optional"`
+	NFCONFIG *LogSetting `yaml:"NFCONFIG" valid:"optional"`
 	NRF      *LogSetting `yaml:"NRF" valid:"optional"`
 	NSSF     *LogSetting `yaml:"NSSF" valid:"optional"`
 	PCF      *LogSetting `yaml:"PCF" valid:"optional"`
@@ -28,7 +29,6 @@ type Logger struct {
 	NWDAF    *LogSetting `yaml:"NWDAF" valid:"optional"`
 	WEBUI    *LogSetting `yaml:"WEBUI" valid:"optional"`
 	SCTPLB   *LogSetting `yaml:"SCTPLB" valid:"optional"`
-	NFCONFIG *LogSetting `yaml:"NFCONFIG" valid:"optional"`
 
 	Aper                         *LogSetting `yaml:"Aper" valid:"optional"`
 	Util                         *LogSetting `yaml:"Util" valid:"optional"`

--- a/logger/logger_config.go
+++ b/logger/logger_config.go
@@ -11,23 +11,24 @@ import (
 )
 
 type Logger struct {
-	AMF    *LogSetting `yaml:"AMF" valid:"optional"`
-	AUSF   *LogSetting `yaml:"AUSF" valid:"optional"`
-	N3IWF  *LogSetting `yaml:"N3IWF" valid:"optional"`
-	NRF    *LogSetting `yaml:"NRF" valid:"optional"`
-	NSSF   *LogSetting `yaml:"NSSF" valid:"optional"`
-	PCF    *LogSetting `yaml:"PCF" valid:"optional"`
-	SMF    *LogSetting `yaml:"SMF" valid:"optional"`
-	UDM    *LogSetting `yaml:"UDM" valid:"optional"`
-	UDR    *LogSetting `yaml:"UDR" valid:"optional"`
-	UPF    *LogSetting `yaml:"UPF" valid:"optional"`
-	NEF    *LogSetting `yaml:"NEF" valid:"optional"`
-	BSF    *LogSetting `yaml:"BSF" valid:"optional"`
-	CHF    *LogSetting `yaml:"CHF" valid:"optional"`
-	UDSF   *LogSetting `yaml:"UDSF" valid:"optional"`
-	NWDAF  *LogSetting `yaml:"NWDAF" valid:"optional"`
-	WEBUI  *LogSetting `yaml:"WEBUI" valid:"optional"`
-	SCTPLB *LogSetting `yaml:"SCTPLB" valid:"optional"`
+	AMF      *LogSetting `yaml:"AMF" valid:"optional"`
+	AUSF     *LogSetting `yaml:"AUSF" valid:"optional"`
+	N3IWF    *LogSetting `yaml:"N3IWF" valid:"optional"`
+	NRF      *LogSetting `yaml:"NRF" valid:"optional"`
+	NSSF     *LogSetting `yaml:"NSSF" valid:"optional"`
+	PCF      *LogSetting `yaml:"PCF" valid:"optional"`
+	SMF      *LogSetting `yaml:"SMF" valid:"optional"`
+	UDM      *LogSetting `yaml:"UDM" valid:"optional"`
+	UDR      *LogSetting `yaml:"UDR" valid:"optional"`
+	UPF      *LogSetting `yaml:"UPF" valid:"optional"`
+	NEF      *LogSetting `yaml:"NEF" valid:"optional"`
+	BSF      *LogSetting `yaml:"BSF" valid:"optional"`
+	CHF      *LogSetting `yaml:"CHF" valid:"optional"`
+	UDSF     *LogSetting `yaml:"UDSF" valid:"optional"`
+	NWDAF    *LogSetting `yaml:"NWDAF" valid:"optional"`
+	WEBUI    *LogSetting `yaml:"WEBUI" valid:"optional"`
+	SCTPLB   *LogSetting `yaml:"SCTPLB" valid:"optional"`
+	NFCONFIG *LogSetting `yaml:"NFCONFIG" valid:"optional"`
 
 	Aper                         *LogSetting `yaml:"Aper" valid:"optional"`
 	Util                         *LogSetting `yaml:"Util" valid:"optional"`


### PR DESCRIPTION
A new service type NFCONFIG is added to Logger. NFCONFIG is used in Webconsole  to manage configuration of NFs.